### PR TITLE
#68 - Allow to define static pages (text-based or binary) 

### DIFF
--- a/jssg/jinja2.py
+++ b/jssg/jinja2.py
@@ -34,8 +34,8 @@ def static_with_hash(path):
     # In development, skip hashing for live reloading
     if settings.DEBUG:
         return staticfiles_storage.url(path)
-        
-    if hasattr(staticfiles_storage, 'stored_name'):
+
+    if hasattr(staticfiles_storage, "stored_name"):
         try:
             hashed_name = staticfiles_storage.stored_name(path)
             return staticfiles_storage.url(hashed_name)

--- a/jssg/management/commands/list-widgets.py
+++ b/jssg/management/commands/list-widgets.py
@@ -71,7 +71,7 @@ class Command(BaseCommand):
             nb_macro_found = 0
             visited = []
 
-            jinja_engine = engines['jinja2']
+            jinja_engine = engines["jinja2"]
             jinja2_env = jinja_engine.env
 
             for template_dir in settings.JFME_TEMPLATES_DIRS:

--- a/jssg/models.py
+++ b/jssg/models.py
@@ -170,7 +170,9 @@ class Document:
         seen_states = set()
         iteration = 0
 
-        substitution_pattern = re.compile(r'\(\(([^)]+)\)\)')  # match ((metadata_name)) patterns in metadata values
+        substitution_pattern = re.compile(
+            r"\(\(([^)]+)\)\)"
+        )  # match ((metadata_name)) patterns in metadata values
 
         while True:
             iteration += 1
@@ -213,14 +215,21 @@ class Document:
                         pattern_to_replace = f"(({metadata_name}))"
 
                         # Check if the referenced metadata exists and is a string
-                        if (metadata_name in substituted_metadata and
-                                isinstance(substituted_metadata[metadata_name], str)):
+                        if metadata_name in substituted_metadata and isinstance(
+                            substituted_metadata[metadata_name], str
+                        ):
 
                             replacement_value = substituted_metadata[metadata_name]
-                            new_value = new_value.replace(pattern_to_replace, replacement_value)
-                            print(f"    Replacing {pattern_to_replace} with '{replacement_value}'")
+                            new_value = new_value.replace(
+                                pattern_to_replace, replacement_value
+                            )
+                            print(
+                                f"    Replacing {pattern_to_replace} with '{replacement_value}'"
+                            )
                         else:
-                            print(f"    Warning: Referenced metadata '{metadata_name}' not found or not a string")
+                            print(
+                                f"    Warning: Referenced metadata '{metadata_name}' not found or not a string"
+                            )
 
                 # Check if this value changed
                 if new_value != original_value:

--- a/jssg/settings.py.tmpl
+++ b/jssg/settings.py.tmpl
@@ -65,6 +65,11 @@ JFME_ADDITIONAL_JINJA2_FILTERS = {}
 # Example: ["/en/index.html"] would exclude the /en/index.html file from pages to be included in generated sitemap.xml
 # This (also) allows to avoid double canonical pages because / and /en/index.html may be both primary page (and we need a / canonical page)
 JFME_SITEMAP_EXCLUDED_LOCATIONS = []
+# Static pages are contents to serve at the root folder (or relative to root folder) compared to static contents
+# which are found in <root>/static/xxx. This is usefull for robots.txt and llms.txt, for example.
+# static pages may be text or binary files - JFME manage the mime type according to the original content
+# Example value: JFME_STATIC_PAGES = ["robots.txt", "llms.txt"]   # add both files to the pages/ folder
+JFME_STATIC_PAGES = []
 
 # Image conversion settings (used by jssg.imagework / convert-images command)
 JFME_RESIZE_PREFIX = ".jfme-reworked__"  # prefix for original backup files

--- a/jssg/sitemaps.py
+++ b/jssg/sitemaps.py
@@ -20,10 +20,15 @@ class MySitemap(Sitemap):
         instead, they must implement the _jssg_sitemap_items() method
         """
         from django.conf import settings
+
         items = []
         found_items = self._jssg_sitemap_items()
         # Exclude items if their location is found in locations to exclude
-        items = [item for item in found_items if self.location(item) not in settings.JFME_SITEMAP_EXCLUDED_LOCATIONS]
+        items = [
+            item
+            for item in found_items
+            if self.location(item) not in settings.JFME_SITEMAP_EXCLUDED_LOCATIONS
+        ]
 
         return items
 

--- a/jssg/urls.py
+++ b/jssg/urls.py
@@ -61,7 +61,6 @@ for spf in settings.JFME_STATIC_PAGES:  # spf = static page filepath
     )
 
 
-
 if len(list(Post.get_posts())) > 0:
     urlpatterns += [
         distill_path("atom.xml", views.PostFeedsView(), name="atom_feed"),
@@ -98,4 +97,3 @@ if len(PostList().categories) > 0:
 urlpatterns += [
     path("jfme/seo_helper", views.jfme_seo_helper, name="jfme_seo_helper"),
 ]
-

--- a/jssg/urls.py
+++ b/jssg/urls.py
@@ -21,6 +21,7 @@ from jssg import settings
 
 from django.contrib.sitemaps.views import sitemap
 from jssg.sitemaps import PageSitemap, PostSitemap, PostListSitemap, ConstantUrlSitemap
+from jssg.views import StaticPageView
 
 urlpatterns = [
     distill_path(
@@ -53,6 +54,13 @@ urlpatterns = [
         name="django.contrib.sitemaps.views.sitemap",
     ),
 ]
+
+for spf in settings.JFME_STATIC_PAGES:  # spf = static page filepath
+    urlpatterns.append(
+        distill_path(spf, StaticPageView.as_view(static_page_filepath=spf), name=spf),
+    )
+
+
 
 if len(list(Post.get_posts())) > 0:
     urlpatterns += [

--- a/jssg/views.py
+++ b/jssg/views.py
@@ -12,22 +12,25 @@
 #
 # You should have received a copy of the GNU General Public License along with
 # this program. If not, see <https://www.gnu.org/licenses/>.
+import mimetypes
+import os
 from pathlib import Path
 from typing import List
 
 from django.conf import settings
 from django.contrib.syndication.views import Feed
 from django.db.models.base import Model as Model
+from django.http import Http404,HttpResponse
 from django.shortcuts import render
 from django.urls import reverse
 from django.utils.feedgenerator import Atom1Feed
-from django.views.generic import DetailView
+from django.views.generic import DetailView, View
 
 from jssg.models import Page, Post, PostList
 
 
 class PostFeedsView(Feed):
-    title = "MY WEBSITE - last articles"
+    title = "Last articles"
     link = ""
     feed_type = Atom1Feed
 
@@ -89,6 +92,46 @@ class PostListView(DetailView):
         return PostList.load_post_list_with_category(
             self.kwargs["category"], self.kwargs["page"]
         )
+
+class StaticPageView(View):
+    """
+    Rendering of static pages. Static pages are raw pages, like a pdf or text file.
+    Compared to static files, they can be found in the original page tree, eg /robots.txt or /en/documentation.pdf.
+    If it was static files, they would be found in /static/robots.txt or /static/en/documentation.pdf, etc
+    """
+    static_page_filepath: str = None  # set via as_view(filename="...")
+
+    def get(self, request):
+        if not self.static_page_filepath:
+            raise Http404("Wrong usage of FileContentView.")
+
+        file_path = ""
+        for folder_path in settings.JFME_PAGES_DIRS:
+            static_page_absolute_path = os.path.join(folder_path, self.static_page_filepath)
+            if os.path.exists(static_page_absolute_path):
+                file_path = static_page_absolute_path
+                print(f"Found {file_path}")
+                break
+
+        if not file_path:
+            print(f"{self.static_page_filepath} not found in {settings.JFME_PAGES_DIRS}")
+            raise Http404("File not found.")
+
+        mime_type, encoding = mimetypes.guess_type(self.static_page_filepath)
+        content_type = mime_type or "application/octet-stream"
+        if encoding:
+            content_type += f"; charset={encoding}"
+
+        print(f"ENCODING IS {encoding}")
+        is_binary = not (mime_type and mime_type.startswith("text/"))
+        open_kwargs = {} if is_binary else {"encoding": "utf-8"}
+
+        content = ""
+        with open(file_path, "rb" if is_binary else "r", **open_kwargs) as f:
+            content = f.read()
+
+        return HttpResponse(content, content_type=content_type)
+
 
 def jfme_seo_helper(request):
 

--- a/jssg/views.py
+++ b/jssg/views.py
@@ -20,7 +20,7 @@ from typing import List
 from django.conf import settings
 from django.contrib.syndication.views import Feed
 from django.db.models.base import Model as Model
-from django.http import Http404,HttpResponse
+from django.http import Http404, HttpResponse
 from django.shortcuts import render
 from django.urls import reverse
 from django.utils.feedgenerator import Atom1Feed
@@ -93,12 +93,14 @@ class PostListView(DetailView):
             self.kwargs["category"], self.kwargs["page"]
         )
 
+
 class StaticPageView(View):
     """
     Rendering of static pages. Static pages are raw pages, like a pdf or text file.
     Compared to static files, they can be found in the original page tree, eg /robots.txt or /en/documentation.pdf.
     If it was static files, they would be found in /static/robots.txt or /static/en/documentation.pdf, etc
     """
+
     static_page_filepath: str = None  # set via as_view(filename="...")
 
     def get(self, request):
@@ -107,14 +109,18 @@ class StaticPageView(View):
 
         file_path = ""
         for folder_path in settings.JFME_PAGES_DIRS:
-            static_page_absolute_path = os.path.join(folder_path, self.static_page_filepath)
+            static_page_absolute_path = os.path.join(
+                folder_path, self.static_page_filepath
+            )
             if os.path.exists(static_page_absolute_path):
                 file_path = static_page_absolute_path
                 print(f"Found {file_path}")
                 break
 
         if not file_path:
-            print(f"{self.static_page_filepath} not found in {settings.JFME_PAGES_DIRS}")
+            print(
+                f"{self.static_page_filepath} not found in {settings.JFME_PAGES_DIRS}"
+            )
             raise Http404("File not found.")
 
         mime_type, encoding = mimetypes.guess_type(self.static_page_filepath)
@@ -137,8 +143,8 @@ def jfme_seo_helper(request):
 
     pages = []
     for page in Page.load_glob(
-            path=list(map(lambda p: Path(p).absolute(), settings.JFME_PAGES_DIRS)),
-            all=True,
+        path=list(map(lambda p: Path(p).absolute(), settings.JFME_PAGES_DIRS)),
+        all=True,
     ):
         if "og:image" in page.metadata:
             og_image = page.metadata["og:image"]


### PR DESCRIPTION
Fixes #68 — The static pages are files found in `pages/` folder and served raw (no processing) from the main directory.